### PR TITLE
feat: make AUTO_REPLY_SUBJECT configurable via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ ENABLE_AUTO_REPLY=false
 # Example: "Auto Reply <autoreply@yourdomain.com>"
 AUTO_REPLY_FROM_EMAIL=
 
+# Auto-reply email subject line (optional, defaults to built-in message)
+# Customize the subject line for automatic thank you emails sent to form senders
+# Default: "Thank you for your message - We'll get back to you soon"
+# Example: "Thanks for contacting us!"
+AUTO_REPLY_SUBJECT=
+
 # Banned words filter (optional, leave empty to disable)
 # Semicolon-separated list of words to block in contact form submissions
 # Checks email, subject, and message content (case-insensitive)

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Complete reference for all configuration options:
 | `API_KEY` | Secure API key for authentication | ❌ | `$(openssl rand -base64 32)` |
 | `ENABLE_AUTO_REPLY` | Send thank you emails to senders | ❌ | `true` |
 | `AUTO_REPLY_FROM_EMAIL` | From address for auto-reply emails (defaults to FROM_EMAIL) | ❌ | `"Auto Reply <autoreply@yourdomain.com>"` |
+| `AUTO_REPLY_SUBJECT` | Subject line for auto-reply emails (defaults to built-in message) | ❌ | `"Thanks for contacting us!"` |
 | `BANNED_WORDS` | Content filter (semicolon-separated) | ❌ | `spam;casino;lottery` |
 | `EMAIL_DOMAIN_WHITELIST` | Allowed email domains only | ❌ | `yourdomain.com;trusted.org` |
 | `EMAIL_DOMAIN_BLACKLIST` | Blocked email domains | ❌ | `spam.com;malicious.net` |

--- a/templates/auto-reply-template.ts
+++ b/templates/auto-reply-template.ts
@@ -8,11 +8,6 @@
 import type { AutoReplyTemplateData } from '../src/types';
 
 /**
- * Auto-reply email subject line
- */
-export const AUTO_REPLY_SUBJECT = `Thank you for your message - We'll get back to you soon`;
-
-/**
  * Generates HTML and text auto-reply email content
  * @param data - Template data with type safety
  * @returns Object containing HTML and text versions of the auto-reply email

--- a/tests/email.test.ts
+++ b/tests/email.test.ts
@@ -4,7 +4,7 @@
 
 import { expect, test, describe, mock, beforeEach } from 'bun:test';
 import { ResendEmailService } from '@/services/email';
-import type { ContactFormData } from '@/types';
+import type { ContactFormData, Environment } from '@/types';
 import { generateEmailTemplate } from '../templates/email-template';
 import { generateAutoReplyTemplate } from '../templates/auto-reply-template';
 
@@ -26,9 +26,15 @@ describe('ResendEmailService', () => {
   const testTargetEmail = 'target@example.com';
   const testFromEmail = 'Test Form <noreply@test.com>';
 
+  const mockEnv: Environment = {
+    RESEND_API_KEY: testApiKey,
+    TARGET_EMAIL: testTargetEmail,
+    FROM_EMAIL: testFromEmail
+  };
+
   beforeEach(() => {
     mockSend.mockClear();
-    emailService = new ResendEmailService(testApiKey, testTargetEmail, testFromEmail);
+    emailService = new ResendEmailService(testApiKey, testTargetEmail, testFromEmail, mockEnv);
   });
 
   test('should send email successfully', async () => {
@@ -250,7 +256,7 @@ describe('ResendEmailService', () => {
 
     beforeEach(() => {
       mockSend.mockClear();
-      emailServiceWithAutoReply = new ResendEmailService(testApiKey, testTargetEmail, testFromEmail, testAutoReplyFromEmail);
+      emailServiceWithAutoReply = new ResendEmailService(testApiKey, testTargetEmail, testFromEmail, mockEnv, testAutoReplyFromEmail);
     });
 
     test('should use AUTO_REPLY_FROM_EMAIL when provided', async () => {
@@ -273,7 +279,7 @@ describe('ResendEmailService', () => {
     });
 
     test('should fallback to FROM_EMAIL when AUTO_REPLY_FROM_EMAIL is undefined', async () => {
-      const emailServiceWithoutAutoReply = new ResendEmailService(testApiKey, testTargetEmail, testFromEmail, undefined);
+      const emailServiceWithoutAutoReply = new ResendEmailService(testApiKey, testTargetEmail, testFromEmail, mockEnv, undefined);
       
       const contactData: ContactFormData = {
         email: 'sender@example.com',
@@ -292,7 +298,7 @@ describe('ResendEmailService', () => {
     });
 
     test('should fallback to FROM_EMAIL when AUTO_REPLY_FROM_EMAIL is empty string', async () => {
-      const emailServiceWithEmptyAutoReply = new ResendEmailService(testApiKey, testTargetEmail, testFromEmail, '');
+      const emailServiceWithEmptyAutoReply = new ResendEmailService(testApiKey, testTargetEmail, testFromEmail, mockEnv, '');
       
       const contactData: ContactFormData = {
         email: 'sender@example.com',


### PR DESCRIPTION
### What Changed
This PR moves the `AUTO_REPLY_SUBJECT` from a build-time constant to a runtime environment variable, allowing users to customize the auto-reply email subject without rebuilding the application.