### PR TITLE
🔬 Experimental 🧪 Add optional single file attachment support (MIME-based, 10MB default, disabled by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,29 @@ EMAIL_DOMAIN_BLACKLIST=
 EMAIL_ADDRESS_BLACKLIST=
 
 # ========================================
+# ATTACHMENTS (Optional)
+# ========================================
+# Single optional attachment per request. Disabled by default.
+# Attachments are sent inline in the request payload as Base64 content (no remote URLs).
+# IMPORTANT: Resend enforces a 40MB maximum email size (including Base64-encoded attachments).
+# Base64 increases size by ~33% — choose ATTACHMENTS_MAX_FILE_SIZE_BYTES accordingly.
+#
+# Only MIME types are used for allow/deny logic (recommended to whitelist common doc/image types).
+# Resend blocks some file extensions regardless of MIME (see README for the full list).
+#
+# Enable/disable attachments (default: false)
+ATTACHMENTS_ENABLED=false
+#
+# Per-file size limit in bytes (default: 10485760 = 10MB)
+ATTACHMENTS_MAX_FILE_SIZE_BYTES=10485760
+#
+# MIME whitelist (semicolon-separated, recommended)
+# Example below allows JSON, CSV, TXT, and common images + PDF
+ATTACHMENTS_MIME_WHITELIST="application/json;text/csv;text/plain;image/png;image/jpeg;image/webp;image/gif;application/pdf"
+#
+# MIME blacklist (semicolon-separated); takes priority over whitelist
+ATTACHMENTS_MIME_BLACKLIST=
+# ========================================
 # VALIDATION LIMITS (Build-time Configuration)
 # ========================================
 # IMPORTANT: These variables are read at BUILD TIME for optimal performance.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.2.19
           
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.2.19
           
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: bun install --frozen-lockfile
         
       - name: Run tests
+        env:
+          BUN_NO_TRANSPILE_CACHE: "1"
         run: |
           echo "🧪 Running test suite..."
           bun test

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -15,7 +15,7 @@ type EmailSendOptions = Parameters<InstanceType<typeof Resend>['emails']['send']
 /**
  * Email service implementation using Resend
  */
-export class ResendEmailService implements EmailService {
+class ResendEmailService implements EmailService {
   private resend: Resend;
   private targetEmail: string;
   private fromEmail: string;
@@ -154,6 +154,10 @@ export class ResendEmailService implements EmailService {
   }
 
 }
+
+// Explicit re-exports for compatibility with Bun's ESM resolver
+export { ResendEmailService };
+export default ResendEmailService;
 
 /**
  * Factory function to create email service

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -15,7 +15,7 @@ type EmailSendOptions = Parameters<InstanceType<typeof Resend>['emails']['send']
 /**
  * Email service implementation using Resend
  */
-class ResendEmailService implements EmailService {
+export class ResendEmailService implements EmailService {
   private resend: Resend;
   private targetEmail: string;
   private fromEmail: string;
@@ -155,8 +155,6 @@ class ResendEmailService implements EmailService {
 
 }
 
-// Explicit re-exports for compatibility with Bun's ESM resolver
-export { ResendEmailService };
 export default ResendEmailService;
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,11 @@ export interface ContactFormData {
   email: string;
   subject: string;
   message: string;
+  /**
+   * Optional single attachment; only honored when ATTACHMENTS_ENABLED=true.
+   * When disabled, presence of this field will cause a 400 error.
+   */
+  attachment?: AttachmentPayload;
 }
 
 export interface ContactFormResponse {
@@ -45,6 +50,15 @@ export interface AutoReplyTemplateData {
 }
 
 /**
+ * Single file attachment payload (Base64 content only; remote URLs are not supported)
+ */
+export interface AttachmentPayload {
+  filename: string;     // e.g., "document.json"
+  contentType: string;  // MIME type, e.g., "application/json"
+  content: string;      // Base64-encoded file content (no data: URI prefix)
+}
+
+/**
  * Template function type for generating email content
  */
 export interface TemplateFunction<T> {
@@ -52,7 +66,7 @@ export interface TemplateFunction<T> {
 }
 
 export interface EmailService {
-  sendEmail(data: ContactFormData, request?: Request): Promise<boolean>;
+  sendEmail(data: ContactFormData, request?: Request, attachment?: AttachmentPayload): Promise<boolean>;
   sendAutoReply(data: ContactFormData): Promise<boolean>;
 }
 
@@ -98,6 +112,12 @@ export interface Environment extends Record<string, string> {
   RATE_LIMIT_EMAIL_ENABLED?: string;
   RATE_LIMIT_EMAIL_LIMIT?: string;
   RATE_LIMIT_EMAIL_WINDOW?: string;
+
+  // Attachments configuration (runtime)
+  ATTACHMENTS_ENABLED?: string;                // "true" | "false" (default: false)
+  ATTACHMENTS_MAX_FILE_SIZE_BYTES?: string;    // per-file limit (default: 10485760 = 10MB)
+  ATTACHMENTS_MIME_WHITELIST?: string;         // semicolon-separated MIME types
+  ATTACHMENTS_MIME_BLACKLIST?: string;         // semicolon-separated MIME types
 }
 
 export interface RequestContext {

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,0 +1,193 @@
+/**
+ * Attachments utilities for Gołąb contact form API
+ * - Single optional attachment, disabled by default
+ * - MIME-based whitelist/blacklist
+ * - Per-file size limit (default 10MB)
+ * - Blocks Resend unsupported file extensions regardless of MIME
+ */
+
+import type { Environment, ValidationError, AttachmentPayload } from '@/types';
+
+/**
+ * Resend unsupported file extensions (case-insensitive)
+ * Source: https://resend.com/docs/knowledge-base/what-attachment-types-are-not-supported
+ */
+const RESEND_UNSUPPORTED_EXTENSIONS = new Set(
+  [
+    '.adp','.app','.asp','.bas','.bat',
+    '.cer','.chm','.cmd','.com','.cpl',
+    '.crt','.csh','.der','.exe','.fxp',
+    '.gadget','.hlp','.hta','.inf','.ins',
+    '.isp','.its','.js','.jse','.ksh',
+    '.lib','.lnk','.mad','.maf','.mag',
+    '.mam','.maq','.mar','.mas','.mat',
+    '.mau','.mav','.maw','.mda','.mdb',
+    '.mde','.mdt','.mdw','.mdz','.msc',
+    '.msh','.msh1','.msh2','.mshxml','.msh1xml',
+    '.msh2xml','.msi','.msp','.mst','.ops',
+    '.pcd','.pif','.plg','.prf','.prg',
+    '.reg','.scf','.scr','.sct','.shb',
+    '.shs','.sys','.ps1','.ps1xml','.ps2',
+    '.ps2xml','.psc1','.psc2','.tmp','.url',
+    '.vb','.vbe','.vbs','.vps','.vsmacros',
+    '.vss','.vst','.vsw','.vxd','.ws',
+    '.wsc','.wsf','.wsh','.xnk'
+  ].map(e => e.toLowerCase())
+);
+
+function parseList(envValue?: string): string[] {
+  if (!envValue) return [];
+  return envValue
+    .split(';')
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isAttachmentsEnabled(env: Environment): boolean {
+  return (env.ATTACHMENTS_ENABLED || '').toLowerCase() === 'true';
+}
+
+export interface AttachmentsConfig {
+  enabled: boolean;
+  maxSizeBytes: number; // default 10MB
+  whitelist: string[];  // MIME types (lowercase)
+  blacklist: string[];  // MIME types (lowercase)
+}
+
+export function getAttachmentsConfig(env: Environment): AttachmentsConfig {
+  const DEFAULT_MAX = 10 * 1024 * 1024; // 10MB
+  let max = DEFAULT_MAX;
+
+  if (env.ATTACHMENTS_MAX_FILE_SIZE_BYTES) {
+    const parsed = parseInt(env.ATTACHMENTS_MAX_FILE_SIZE_BYTES.trim(), 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      max = parsed;
+    } else {
+      (globalThis as any).console?.warn(`⚠️  [Gołąb] Invalid ATTACHMENTS_MAX_FILE_SIZE_BYTES="${env.ATTACHMENTS_MAX_FILE_SIZE_BYTES}", using default ${DEFAULT_MAX}`);
+    }
+  }
+
+  const whitelist = parseList(env.ATTACHMENTS_MIME_WHITELIST);
+  const blacklist = parseList(env.ATTACHMENTS_MIME_BLACKLIST);
+
+  return {
+    enabled: isAttachmentsEnabled(env),
+    maxSizeBytes: max,
+    whitelist,
+    blacklist
+  };
+}
+
+/**
+ * Compute decoded bytes length for base64 string without allocating buffers.
+ * Assumes input contains only base64 characters optionally padded with '='.
+ */
+export function base64ByteLength(b64: string): number {
+  // Remove whitespace
+  const str = b64.replace(/\s+/g, '');
+  // Basic base64 validity check (not exhaustive)
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(str)) {
+    return -1;
+  }
+  if (str.length % 4 !== 0) {
+    return -1;
+  }
+  const padding = str.endsWith('==') ? 2 : str.endsWith('=') ? 1 : 0;
+  return (str.length * 3) / 4 - padding;
+}
+
+function getExtension(filename: string): string {
+  const idx = filename.lastIndexOf('.');
+  if (idx === -1 || idx === filename.length - 1) return '';
+  return filename.slice(idx).toLowerCase(); // includes dot, e.g. ".pdf"
+}
+
+export function isUnsupportedExtension(filename: string): boolean {
+  const ext = getExtension(filename);
+  if (!ext) return false;
+  return RESEND_UNSUPPORTED_EXTENSIONS.has(ext);
+}
+
+export function isMimeAllowed(mime: string, whitelist: string[], blacklist: string[]): boolean {
+  const m = mime.trim().toLowerCase();
+  if (!m) return false;
+  if (blacklist.includes(m)) return false;
+  if (whitelist.length > 0 && !whitelist.includes(m)) return false;
+  return true;
+}
+
+export type AttachmentValidationResult =
+  | { ok: true; value: AttachmentPayload }
+  | { ok: false; errors: ValidationError[] };
+
+/**
+ * Validates and normalizes an attachment candidate into AttachmentPayload
+ * - Requires fields: filename, contentType (MIME), content (base64)
+ * - Validates base64 shape and decoded size against config
+ * - Validates MIME via whitelist/blacklist with blacklist priority
+ * - Blocks known unsupported extensions by Resend
+ */
+export function validateAndNormalizeAttachment(candidate: unknown, config: AttachmentsConfig): AttachmentValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (candidate === null || typeof candidate !== 'object') {
+    return { ok: false, errors: [{ field: 'attachment', message: 'Invalid attachment object' }] };
+  }
+
+  const obj = candidate as Record<string, unknown>;
+  const filename = typeof obj['filename'] === 'string' ? (obj['filename'] as string).trim() : '';
+  const contentType = typeof obj['contentType'] === 'string' ? (obj['contentType'] as string).trim().toLowerCase() : '';
+  const content = typeof obj['content'] === 'string' ? (obj['content'] as string).trim() : '';
+
+  if (!filename) {
+    errors.push({ field: 'attachment.filename', message: 'Filename is required' });
+  }
+  if (!contentType) {
+    errors.push({ field: 'attachment.contentType', message: 'Content type (MIME) is required' });
+  }
+  if (!content) {
+    errors.push({ field: 'attachment.content', message: 'Base64 content is required' });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  // Validate extension blacklist from Resend
+  if (isUnsupportedExtension(filename)) {
+    errors.push({ field: 'attachment.filename', message: 'File extension is not supported by the email provider' });
+  }
+
+  // Validate MIME whitelist/blacklist
+  if (!isMimeAllowed(contentType, config.whitelist, config.blacklist)) {
+    // Disambiguate reason
+    if (config.blacklist.includes(contentType)) {
+      errors.push({ field: 'attachment.contentType', message: 'MIME type is blacklisted' });
+    } else if (config.whitelist.length > 0 && !config.whitelist.includes(contentType)) {
+      errors.push({ field: 'attachment.contentType', message: 'MIME type is not in whitelist' });
+    } else {
+      errors.push({ field: 'attachment.contentType', message: 'Invalid MIME type' });
+    }
+  }
+
+  // Validate base64 and size
+  const size = base64ByteLength(content);
+  if (size < 0) {
+    errors.push({ field: 'attachment.content', message: 'Invalid Base64 content' });
+  } else if (size > config.maxSizeBytes) {
+    errors.push({ field: 'attachment.content', message: `Attachment exceeds maximum size of ${config.maxSizeBytes} bytes` });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  // Normalized payload for Resend
+  const value: AttachmentPayload = {
+    filename,
+    contentType,
+    content
+  };
+
+  return { ok: true, value };
+}

--- a/tests/attachments.test.ts
+++ b/tests/attachments.test.ts
@@ -29,7 +29,11 @@ describe('Attachments Feature', () => {
   // Mock email service factory to capture attachment argument
   const mockEmailService = {
     sendEmail: (data: any, request?: Request, attachment?: any) => {
-      captured = { data, request, attachment };
+      captured = {
+        data,
+        ...(request !== undefined ? { request } : {}),
+        ...(attachment !== undefined ? { attachment } : {}),
+      };
       return mockSendEmail();
     },
     sendAutoReply: mock(() => Promise.resolve(true))

--- a/tests/attachments.test.ts
+++ b/tests/attachments.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for single optional attachment handling
+ */
+
+import { expect, test, describe, mock, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import type { Environment } from '@/types';
+
+// Utilities for building sample base64 payloads
+const b64 = {
+  // "{}"
+  json: 'e30=',
+  // "Hello"
+  hello: 'SGVsbG8='
+};
+
+// Capture arguments passed to email service
+type CapturedArgs = {
+  data: any;
+  request?: Request;
+  attachment?: { filename: string; contentType: string; content: string };
+} | null;
+
+describe('Attachments Feature', () => {
+  let app: Hono<{ Bindings: Environment }>;
+  const mockSendEmail = mock(() => Promise.resolve(true));
+  let captured: CapturedArgs = null;
+
+  // Mock email service factory to capture attachment argument
+  const mockEmailService = {
+    sendEmail: (data: any, request?: Request, attachment?: any) => {
+      captured = { data, request, attachment };
+      return mockSendEmail();
+    },
+    sendAutoReply: mock(() => Promise.resolve(true))
+  };
+
+  beforeEach(async () => {
+    mockSendEmail.mockClear();
+    captured = null;
+
+    mock.module('@/services/email', () => ({
+      createEmailService: mock(() => mockEmailService)
+    }));
+
+    const { default: createApp } = await import('@/index');
+    app = createApp;
+  });
+
+  test('should return 400 when attachments are disabled and attachment is provided', async () => {
+    const env: Environment = {
+      TARGET_EMAIL: 'target@example.com',
+      RESEND_API_KEY: 'test-key',
+      FROM_EMAIL: 'Test Form <noreply@test.com>',
+      ALLOWED_ORIGINS: '*',
+      // ATTACHMENTS_ENABLED not set (defaults to disabled)
+    };
+
+    const req = new Request('http://localhost/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'user@example.com',
+        subject: 'Subject',
+        message: 'Message with enough length',
+        attachment: {
+          filename: 'data.json',
+          contentType: 'application/json',
+          content: b64.json
+        }
+      })
+    });
+
+    const res = await app.fetch(req, env);
+    const payload = await res.json();
+
+    expect(res.status).toBe(400);
+    expect((payload as any).error).toBe('Attachments are disabled');
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  test('should accept request without attachment when enabled (backward compatible)', async () => {
+    const env: Environment = {
+      TARGET_EMAIL: 'target@example.com',
+      RESEND_API_KEY: 'test-key',
+      FROM_EMAIL: 'Test Form <noreply@test.com>',
+      ALLOWED_ORIGINS: '*',
+      ATTACHMENTS_ENABLED: 'true',
+      ATTACHMENTS_MIME_WHITELIST: 'application/json;text/plain;image/png;image/jpeg'
+    };
+
+    const req = new Request('http://localhost/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'user@example.com',
+        subject: 'Subject',
+        message: 'Message with enough length'
+      })
+    });
+
+    const res = await app.fetch(req, env);
+    const payload = await res.json();
+
+    expect(res.status).toBe(200);
+    expect((payload as any).success).toBe(true);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(captured?.attachment).toBeUndefined();
+  });
+
+  test('should send with valid attachment when enabled and MIME is whitelisted', async () => {
+    const env: Environment = {
+      TARGET_EMAIL: 'target@example.com',
+      RESEND_API_KEY: 'test-key',
+      FROM_EMAIL: 'Test Form <noreply@test.com>',
+      ALLOWED_ORIGINS: '*',
+      ATTACHMENTS_ENABLED: 'true',
+      ATTACHMENTS_MIME_WHITELIST: 'application/json;text/plain;image/png;image/jpeg'
+    };
+
+    const req = new Request('http://localhost/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'user@example.com',
+        subject: 'Subject',
+        message: 'Message with enough length',
+        attachment: {
+          filename: 'data.json',
+          contentType: 'application/json',
+          content: b64.json
+        }
+      })
+    });
+
+    const res = await app.fetch(req, env);
+    const payload = await res.json();
+
+    expect(res.status).toBe(200);
+    expect((payload as any).success).toBe(true);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(captured?.attachment).toBeDefined();
+    expect(captured?.attachment?.filename).toBe('data.json');
+    expect(captured?.attachment?.contentType).toBe('application/json');
+    expect(captured?.attachment?.content).toBe(b64.json);
+  });
+
+  test('should reject when MIME not in whitelist', async () => {
+    const env: Environment = {
+      TARGET_EMAIL: 'target@example.com',
+      RESEND_API_KEY: 'test-key',
+      FROM_EMAIL: 'Test Form <noreply@test.com>',
+      ALLOWED_ORIGINS: '*',
+      ATTACHMENTS_ENABLED: 'true',
+      ATTACHMENTS_MIME_WHITELIST: 'application/json;text/plain'
+    };
+
+    const req = new Request('http://localhost/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'user@example.com',
+        subject: 'Subject',
+        message: 'Message with enough length',
+        attachment: {
+          filename: 'file.bin',
+          contentType: 'application/octet-stream',
+          content: b64.hello
+        }
+      })
+    });
+
+    const res = await app.fetch(req, env);
+    const payload = await res.json();
+
+    expect(res.status).toBe(400);
+    expect((payload as any).error).toBe('Validation failed');
+    const messages = ((payload as any).details || []).map((d: any) => d.message);
+    expect(messages.join(' ')).toContain('whitelist');
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  test('should reject when MIME blacklisted even if whitelisted', async () => {
+    const env: Environment = {
+      TARGET_EMAIL: 'target@example.com',
+      RESEND_API_KEY: 'test-key',
+      FROM_EMAIL: 'Test Form <noreply@test.com>',
+      ALLOWED_ORIGINS: '*',
+      ATTACHMENTS_ENABLED: 'true',
+      ATTACHMENTS_MIME_WHITELIST: 'application/json',
+      ATTACHMENTS_MIME_BLACKLIST: 'application/json'
+    };
+
+    const req = new Request('http://localhost/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'user@example.com',
+        subject: 'Subject',
+        message: 'Message with enough length',
+        attachment: {
+          filename: 'data.json',
+          contentType: 'application/json',
+          content: b64.json
+        }
+      })
+    });
+
+    const res = await app.fetch(req, env);
+    const payload = await res.json();
+
+    expect(res.status).toBe(400);
+    expect((payload as any).error).toBe('Validation failed');
+    const messages = ((payload as any).details || []).map((d: any) => d.message);
+    expect(messages.join(' ')).toContain('blacklisted');
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  test('should reject unsupported extension regardless of MIME', async () => {
+    const env: Environment = {
+      TARGET_EMAIL: 'target@example.com',
+      RESEND_API_KEY: 'test-key',
+      FROM_EMAIL: 'Test Form <noreply@test.com>',
+      ALLOWED_ORIGINS: '*',
+      ATTACHMENTS_ENABLED: 'true',
+      ATTACHMENTS_MIME_WHITELIST: 'application/json;application/pdf'
+    };
+
+    const req = new Request('http://localhost/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'user@example.com',
+        subject: 'Subject',
+        message: 'Message with enough length',
+        attachment: {
+          filename: 'bad.exe',
+          contentType: 'application/pdf',
+          content: b64.hello
+        }
+      })
+    });
+
+    const res = await app.fetch(req, env);
+    const payload = await res.json();
+
+    expect(res.status).toBe(400);
+    expect((payload as any).error).toBe('Validation failed');
+    const messages = ((payload as any).details || []).map((d: any) => d.message);
+    expect(messages.join(' ')).toContain('not supported');
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  test('should enforce per-file size limit', async () => {
+    const env: Environment = {
+      TARGET_EMAIL: 'target@example.com',
+      RESEND_API_KEY: 'test-key',
+      FROM_EMAIL: 'Test Form <noreply@test.com>',
+      ALLOWED_ORIGINS: '*',
+      ATTACHMENTS_ENABLED: 'true',
+      ATTACHMENTS_MIME_WHITELIST: 'text/plain',
+      ATTACHMENTS_MAX_FILE_SIZE_BYTES: '3' // 3 bytes max
+    };
+
+    // "Hello" => 5 bytes decoded
+    const req = new Request('http://localhost/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'user@example.com',
+        subject: 'Subject',
+        message: 'Message with enough length',
+        attachment: {
+          filename: 'hello.txt',
+          contentType: 'text/plain',
+          content: b64.hello
+        }
+      })
+    });
+
+    const res = await app.fetch(req, env);
+    const payload = await res.json();
+
+    expect(res.status).toBe(400);
+    expect((payload as any).error).toBe('Validation failed');
+    const messages = ((payload as any).details || []).map((d: any) => d.message);
+    expect(messages.join(' ')).toContain('exceeds maximum size');
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/tests/email.test.ts
+++ b/tests/email.test.ts
@@ -182,6 +182,31 @@ describe('ResendEmailService', () => {
     expect(callArgs.text).toContain('Thank you for your message!');
   });
 
+  test('should forward attachment when provided', async () => {
+    const contactData: ContactFormData = {
+      email: 'sender@example.com',
+      subject: 'With Attachment',
+      message: 'This is a test message with attachment.'
+    };
+
+    const attachment = {
+      filename: 'data.json',
+      contentType: 'application/json',
+      content: 'e30=' // "{}"
+    };
+
+    const result = await emailService.sendEmail(contactData, undefined as any, attachment);
+    expect(result).toBe(true);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+
+    const callArgs = (mockSend.mock.calls as any)[0][0];
+    expect(callArgs.attachments).toBeDefined();
+    expect(Array.isArray(callArgs.attachments)).toBe(true);
+    expect(callArgs.attachments.length).toBe(1);
+    expect(callArgs.attachments[0].filename).toBe('data.json');
+    expect(callArgs.attachments[0].content).toBe('e30=');
+  });
+
   test('should handle auto-reply email sending failure', async () => {
     // Mock a failed email send
     mockSend.mockImplementationOnce(() => Promise.resolve({ data: { id: '' } }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "types": ["@cloudflare/workers-types", "bun-types"],


### PR DESCRIPTION
## Summary

 - Implements optional single attachment in /api/contact.
 - Attachments are sent inline (Base64) and validated by MIME whitelist/blacklist, per-file size, and Resend’s unsupported extension list.
 - Feature is disabled by default to preserve existing behavior; when disabled, requests containing attachment get 400.
 
### Configuration
 - `ATTACHMENTS_ENABLED="true"` to enable.
 - `ATTACHMENTS_MAX_FILE_SIZE_BYTES` default: 10485760 (10 MB).
 - `ATTACHMENTS_MIME_WHITELIST` recommended defaults: application/json;text/csv;text/plain;image/png;image/jpeg;image/webp;image/gif;application/pdf
 - ATTACHMENTS_MIME_BLACKLIST optional; overrides whitelist.
    
### Validation and constraints
 - Decoded Base64 size checked vs ATTACHMENTS_MAX_FILE_SIZE_BYTES.
 - Unsupported extensions blocked regardless of MIME (see README for full list).
 - Resend global limit: 40 MB per email including Base64 overhead.
 
### API
 - New optional field when enabled: attachment: { filename: string, contentType: string, content: string (Base64) }
 - Required fields (email, subject, message) remain unchanged.
 - Disabled by default; requests without attachments behave as before.
    
### Tests
 - Added tests/attachments.test.ts for end-to-end handler validation of attachments.
 - Extended tests/email.test.ts to assert attachment forwarding.
    
### Backward compatibility
 - No change for requests without attachments.
 - Disabled by default; enabling is opt-in via env.
    
### References
 - Resend attachments docs: https://resend.com/docs/dashboard/emails/attachments
 - Unsupported extensions source linked in README.
    
